### PR TITLE
[WIP] Adicionando a API status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.dccache
+package-lock.json

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 Licença MIT
 
-Direitos autorais (c) 2019 Discloudbot.com.
+Direitos autorais (c) 2019-2021 Discloudbot.com.
 
 É concedida permissão, gratuitamente, a qualquer pessoa que obtenha uma cópia
 deste software e arquivos de documentação associados (o "Software"), para lidar

--- a/index.js
+++ b/index.js
@@ -52,6 +52,7 @@ function formatoMb(bytes) {
 }
 
 const axios = require('axios');
+const FormData = require('form-data')
 
 class APIstatus {
     constructor(token) {
@@ -70,16 +71,39 @@ class APIstatus {
     }
     getBot(id) {
         return new Promise((res, rej) => {
+            if (id == undefined) {return rej("Need bot id")}
             this.instance.get(`/bot/${id}`).then(x => res(x.data))
                 .catch(err => rej(err))
         })
     }
     getBotLogs(id) {
         return new Promise((res, rej) => {
+            if (id == undefined) {return rej("Need bot id")}
             this.instance.get(`/bot/${id}/logs`).then(x => res(x.data))
                 .catch(err => rej(err))
         })
     }
+    postBotRestart(id = undefined) {
+        return new Promise((res, rej) => {
+            if (id == undefined) {return rej("Need bot id")}
+            this.instance.post(`/bot/${id}/restart`).then(x => res(x.data))
+                .catch(err => rej(err))
+        })
+    }
+    postBotCommit(id, pathZip, restartBot = false) {
+        return new Promise((res, rej) => {
+            if (id == undefined) {return rej("Need bot id")}
+            if (pathZip == undefined) {return rej("Need path zip")}
+            const fileZip = fs.createReadStream(pathZip).catch(err => rej(err))
+            let form = new FormData();
+            form.append('file', fileZip);
+            this.instance.post(`/bot/${id}/commit?restart=${restartBot}`, form, {
+                headers: form.getHeaders({ 'api-token': this.token })
+            }).then(x => res(x.data))
+                .catch(err => rej(err))
+        })
+    }
+
 }
 
 module.exports = {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Discloud
+Copyright 2019-2021 Discloud
 Todos os direitos reservados.
 
 AVISO: A Discloud permite que você use, modifique e distribua esse arquivo em
@@ -15,9 +15,9 @@ function ram() {
     try {
         let usoBytes = fs.readFileSync(`/sys/fs/cgroup/memory/memory.max_usage_in_bytes`).toString();
         let totalBytes = fs.readFileSync(`/sys/fs/cgroup/memory/memory.limit_in_bytes`).toString();
-        return formatoMb(usoBytes)+'/'+formatoMb(totalBytes)+'MB'
+        return formatoMb(usoBytes) + '/' + formatoMb(totalBytes) + 'MB'
     } catch (err) {
-       throw new Error("Dados não encontrados")
+        throw new Error("Dados não encontrados")
     }
 }
 function usoRam() {
@@ -25,7 +25,7 @@ function usoRam() {
         let usoBytes = fs.readFileSync(`/sys/fs/cgroup/memory/memory.max_usage_in_bytes`).toString();//588132352
         return converter(usoBytes)
     } catch (err) {
-       throw new Error("Dados não encontrados")
+        throw new Error("Dados não encontrados")
     }
 }
 function totalRam() {
@@ -33,7 +33,7 @@ function totalRam() {
         let totalBytes = fs.readFileSync(`/sys/fs/cgroup/memory/memory.limit_in_bytes`).toString(); //1400897536
         return converter(totalBytes)
     } catch (err) {
-       throw new Error("Dados não encontrados")
+        throw new Error("Dados não encontrados")
     }
 }
 
@@ -41,9 +41,9 @@ function converter(bytes) {
     let formatos = ['B', 'KB', 'MB', 'GB', 'TB'];
     if (bytes == 0) return '0B';
     let i = parseInt(Math.floor(Math.log(bytes) / Math.log(1024)));
-    if(i <= 2) return Math.round(bytes / Math.pow(1024, i), 2) + formatos[i];
-    if((bytes / Math.pow(1024, i)).toFixed(3).includes(".00")) return Math.round(bytes / Math.pow(1024, i), 2) + formatos[i];
-    if((bytes / Math.pow(1024, i)).toFixed(3).includes(".0")) return ((bytes / Math.pow(1024, i)).toFixed(3) + formatos[i]).replace("0","")
+    if (i <= 2) return Math.round(bytes / Math.pow(1024, i), 2) + formatos[i];
+    if ((bytes / Math.pow(1024, i)).toFixed(3).includes(".00")) return Math.round(bytes / Math.pow(1024, i), 2) + formatos[i];
+    if ((bytes / Math.pow(1024, i)).toFixed(3).includes(".0")) return ((bytes / Math.pow(1024, i)).toFixed(3) + formatos[i]).replace("0", "")
     return (bytes / Math.pow(1024, i)).toFixed(3) + formatos[i];
 }
 
@@ -51,8 +51,34 @@ function formatoMb(bytes) {
     return Math.round(bytes / Math.pow(1024, 2), 2);
 }
 
+const axios = require('axios');
+
+class APIstatus {
+    constructor(token) {
+        this.token = token;
+        this.instance = axios.create({
+            baseURL: 'https://discloud.app/status',
+            timeout: 5000,
+            headers: { 'api-token': this.token }
+        });
+    }
+    getUser() {
+        return new Promise((res, rej) => {
+            this.instance.get("/user").then(x => res(x.data))
+                .catch(err => rej(err))
+        })
+    }
+    getBot(id) {
+        return new Promise((res, rej) => {
+            this.instance.get(`/bot/${id}`).then(x => res(x.data))
+                .catch(err => rej(err))
+        })
+    }
+}
+
 module.exports = {
     usoRam,
     totalRam,
-    ram
- }
+    ram,
+    APIstatus
+}

--- a/index.js
+++ b/index.js
@@ -74,6 +74,12 @@ class APIstatus {
                 .catch(err => rej(err))
         })
     }
+    getBotLogs(id) {
+        return new Promise((res, rej) => {
+            this.instance.get(`/bot/${id}/logs`).then(x => res(x.data))
+                .catch(err => rej(err))
+        })
+    }
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discloud-status",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Esse módulo Nodejs funciona apenas no linux, e foi criado exclusivamente para atender os usuários da discloudbot.com",
   "main": "index.js",
   "scripts": {
@@ -12,5 +12,8 @@
   },
   "keywords": [],
   "author": "Pedro Ricardo",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "axios": "^0.24.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "author": "Pedro Ricardo",
   "license": "MIT",
   "dependencies": {
-    "axios": "^0.24.0"
+    "axios": "^0.25.0",
+    "form-data": "^4.0.0"
   }
 }


### PR DESCRIPTION
Este Pull Resquet trata para adicionar ao modulo acesso mais rápido para os usuários a API de Status da Discloud

Notas extras:
- O usuário **\<Morty/>#2925 `(665200472596152341)`** forneceu um codigo base para usar como base

Exemplos de como o codigo:
- Sem promisse:
> ```js
> const DiscloudAPI = require("discloud-status");
>
> const status = new DiscloudAPI.APIstatus("Your API Key");
>
> // Get the Bot info from the API
> status.getBot("Your Bot ID").then(bot => {
>     console.log(bot);
> });
> 
> // Get the User info from the API
> status.getUser().then(user => {
>     console.log(user);
> });
>```